### PR TITLE
Deduplicate longest common subsequence logic

### DIFF
--- a/src/DeepDiffs.jl
+++ b/src/DeepDiffs.jl
@@ -6,7 +6,7 @@ export SimpleDiff, VectorDiff, StringDiff, DictDiff
 # Helper function for comparing two instances of a type for equality by field
 function fieldequal(x::T, y::T) where T
     for f in fieldnames(T)
-        getfield(x, f) == getfield(y, f) || return false
+        isequal(getfield(x, f), getfield(y, f)) || return false
     end
     true
 end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -34,7 +34,7 @@ function deepdiff(X::Vector, Y::Vector)
                 lengths[i+1, j+1] = lengths[i, j] + 1
                 backtracks[i+1, j+1] = (1, 1)
             else
-                (lengths[i+1, j+1], backtracks[i+1, j+1]) = _argmax(lengths[i+1, j], lengths[i, j+1])
+                lengths[i+1, j+1], backtracks[i+1, j+1] = _argmax(lengths[i+1, j], lengths[i, j+1])
             end
         end
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -23,36 +23,37 @@ function deepdiff(X::Vector, Y::Vector)
     # substrings.
 
     lengths = zeros(Int, length(X)+1, length(Y)+1)
-    backtracks = fill(:nothing, axes(lengths))
+    backtracks = fill(:nothing, length(X), length(Y))
 
     for (j, v2) in enumerate(Y)
         for (i, v1) in enumerate(X)
             if isequal(v1, v2)
                 lengths[i+1, j+1] = lengths[i, j] + 1
-                backtracks[i+1, j+1] = :XY
+                backtracks[i, j] = :XY
             else
-                (lengths[i+1, j+1], backtracks[i+1, j+1]) = _argmax(lengths[i+1, j], lengths[i, j+1])
+                (lengths[i+1, j+1], backtracks[i, j]) = _argmax(lengths[i+1, j], lengths[i, j+1])
             end
         end
     end
 
     removed = Int[]
     added = Int[]
-    backtrack(lengths, removed, added, X, Y, length(X), length(Y))
+
+    backtrack(lengths, backtracks, removed, added, X, Y, length(X), length(Y))
 
     VectorDiff(X, Y, removed, added)
 end
 
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
-function backtrack(lengths, removed, added, X, Y, i, j)
-    if i > 0 && j > 0 && isequal(X[i], Y[j])
-        backtrack(lengths, removed, added, X, Y, i-1, j-1)
-    elseif j > 0 && (i == 0 || lengths[i+1, j] ≥ lengths[i, j+1])
-        backtrack(lengths, removed, added, X, Y, i, j-1)
+function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
+    if i > 0 && j > 0 && backtracks[i, j] == :XY
+        backtrack(lengths, backtracks, removed, added, X, Y, i-1, j-1)
+    elseif j > 0 && (i == 0 || backtracks[i, j] == :X)
+        backtrack(lengths, backtracks, removed, added, X, Y, i, j-1)
         push!(added, j)
-    elseif i > 0 && (j == 0 || lengths[i+1, j] < lengths[i, j+1])
-        backtrack(lengths, removed, added, X, Y, i-1, j)
+    elseif i > 0 && (j == 0 ||  backtracks[i, j] == :Y)
+        backtrack(lengths, backtracks, removed, added, X, Y, i-1, j)
         push!(removed, i)
     end
 end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -51,13 +51,13 @@ end
 # to the added and removed lists as we go
 function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
     bt = backtracks[i+1, j+1]
-    if bt == (1, 1)
+    if bt != (0, 0)
         backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
-    elseif bt == (0, 1)
-        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
+    end
+
+    if bt == (0, 1)
         push!(added, j)
     elseif bt == (1, 0)
-        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
         push!(removed, i)
     end
 end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -13,6 +13,8 @@ changed(diff::VectorDiff) = Int[]
 
 Base.:(==)(d1::VectorDiff, d2::VectorDiff) = fieldequal(d1, d2)
 
+_argmax(x, y) = x ≥ y ? (x, :X) : (y, :Y)
+
 # diffing an array is an application of the Longest Common Subsequence problem:
 # https://en.wikipedia.org/wiki/Longest_common_subsequence_problem
 function deepdiff(X::Vector, Y::Vector)
@@ -29,12 +31,7 @@ function deepdiff(X::Vector, Y::Vector)
                 lengths[i+1, j+1] = lengths[i, j] + 1
                 backtracks[i+1, j+1] = :XY
             else
-                (lengths[i+1, j+1], backtracks[i+1, j+1]) =
-                    if lengths[i+1, j] ≥ lengths[i, j+1]
-                        (lengths[i+1, j], :X)
-                    else
-                        (lengths[i, j+1], :Y)
-                    end
+                (lengths[i+1, j+1], backtracks[i+1, j+1]) = _argmax(lengths[i+1, j], lengths[i, j+1])
             end
         end
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -42,19 +42,20 @@ function deepdiff(X::Vector, Y::Vector)
     removed = Int[]
     added = Int[]
 
-    backtrack(backtracks, removed, added, length(X)+1, length(Y)+1)
+    backtrack(backtracks, removed, added, (length(X)+1, length(Y)+1))
 
     VectorDiff(X, Y, removed, added)
 end
 
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
-function backtrack(backtracks, removed, added, i, j)
-    bt = backtracks[i, j]
+function backtrack(backtracks, removed, added, ij)
+    bt = backtracks[ij...]
     if bt != (0, 0)
-        backtrack(backtracks, removed, added, ((i, j) .- bt)...)
+        backtrack(backtracks, removed, added, ij .- bt)
     end
 
+    (i, j) = ij
     if bt == (0, 1)
         push!(added, j-1)
     elseif bt == (1, 0)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -24,6 +24,9 @@ function deepdiff(X::Vector, Y::Vector)
 
     lengths = zeros(Int, length(X)+1, length(Y)+1)
     backtracks = fill(:nothing, axes(lengths))
+    backtracks[1,2:end] .= :X
+    backtracks[2:end,1] .= :Y
+    backtracks[1,1] = :nothing
 
     for (j, v2) in enumerate(Y)
         for (i, v1) in enumerate(X)
@@ -47,12 +50,12 @@ end
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
 function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
-    if i > 0 && j > 0 && backtracks[i+1, j+1] == :XY
+    if backtracks[i+1, j+1] == :XY
         backtrack(lengths, backtracks, removed, added, X, Y, i-1, j-1)
-    elseif j > 0 && (i == 0 || backtracks[i+1, j+1] == :X)
+    elseif backtracks[i+1, j+1] == :X
         backtrack(lengths, backtracks, removed, added, X, Y, i, j-1)
         push!(added, j)
-    elseif i > 0 && (j == 0 ||  backtracks[i+1, j+1] == :Y)
+    elseif backtracks[i+1, j+1] == :Y
         backtrack(lengths, backtracks, removed, added, X, Y, i-1, j)
         push!(removed, i)
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -42,17 +42,17 @@ function deepdiff(X::Vector, Y::Vector)
     removed = Int[]
     added = Int[]
 
-    backtrack(lengths, backtracks, removed, added, X, Y, length(X), length(Y))
+    backtrack(backtracks, removed, added, length(X), length(Y))
 
     VectorDiff(X, Y, removed, added)
 end
 
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
-function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
+function backtrack(backtracks, removed, added, i, j)
     bt = backtracks[i+1, j+1]
     if bt != (0, 0)
-        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
+        backtrack(backtracks, removed, added, ((i, j) .- bt)...)
     end
 
     if bt == (0, 1)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -24,7 +24,7 @@ function deepdiff(X::Vector, Y::Vector)
 
     for (j, v2) in enumerate(Y)
         for (i, v1) in enumerate(X)
-            if v1 == v2
+            if isequal(v1, v2)
                 lengths[i+1, j+1] = lengths[i, j] + 1
             else
                 lengths[i+1, j+1] = max(lengths[i+1, j], lengths[i, j+1])
@@ -42,7 +42,7 @@ end
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
 function backtrack(lengths, removed, added, X, Y, i, j)
-    if i > 0 && j > 0 && X[i] == Y[j]
+    if i > 0 && j > 0 && isequal(X[i], Y[j])
         backtrack(lengths, removed, added, X, Y, i-1, j-1)
     elseif j > 0 && (i == 0 || lengths[i+1, j] ≥ lengths[i, j+1])
         backtrack(lengths, removed, added, X, Y, i, j-1)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -42,7 +42,7 @@ function deepdiff(X::Vector, Y::Vector)
     removed = Int[]
     added = Int[]
 
-    backtrack(backtracks, removed, added, length(X), length(Y))
+    backtrack(backtracks, removed, added, length(X)+1, length(Y)+1)
 
     VectorDiff(X, Y, removed, added)
 end
@@ -50,15 +50,15 @@ end
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
 function backtrack(backtracks, removed, added, i, j)
-    bt = backtracks[i+1, j+1]
+    bt = backtracks[i, j]
     if bt != (0, 0)
         backtrack(backtracks, removed, added, ((i, j) .- bt)...)
     end
 
     if bt == (0, 1)
-        push!(added, j)
+        push!(added, j-1)
     elseif bt == (1, 0)
-        push!(removed, i)
+        push!(removed, i-1)
     end
 end
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -21,13 +21,20 @@ function deepdiff(X::Vector, Y::Vector)
     # substrings.
 
     lengths = zeros(Int, length(X)+1, length(Y)+1)
+    backtracks = fill(:nothing, axes(lengths))
 
     for (j, v2) in enumerate(Y)
         for (i, v1) in enumerate(X)
             if isequal(v1, v2)
                 lengths[i+1, j+1] = lengths[i, j] + 1
+                backtracks[i+1, j+1] = :XY
             else
-                lengths[i+1, j+1] = max(lengths[i+1, j], lengths[i, j+1])
+                (lengths[i+1, j+1], backtracks[i+1, j+1]) =
+                    if lengths[i+1, j] ≥ lengths[i, j+1]
+                        (lengths[i+1, j], :X)
+                    else
+                        (lengths[i, j+1], :Y)
+                    end
             end
         end
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -23,15 +23,15 @@ function deepdiff(X::Vector, Y::Vector)
     # substrings.
 
     lengths = zeros(Int, length(X)+1, length(Y)+1)
-    backtracks = fill(:nothing, length(X), length(Y))
+    backtracks = fill(:nothing, axes(lengths))
 
     for (j, v2) in enumerate(Y)
         for (i, v1) in enumerate(X)
             if isequal(v1, v2)
                 lengths[i+1, j+1] = lengths[i, j] + 1
-                backtracks[i, j] = :XY
+                backtracks[i+1, j+1] = :XY
             else
-                (lengths[i+1, j+1], backtracks[i, j]) = _argmax(lengths[i+1, j], lengths[i, j+1])
+                (lengths[i+1, j+1], backtracks[i+1, j+1]) = _argmax(lengths[i+1, j], lengths[i, j+1])
             end
         end
     end
@@ -47,12 +47,12 @@ end
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
 function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
-    if i > 0 && j > 0 && backtracks[i, j] == :XY
+    if i > 0 && j > 0 && backtracks[i+1, j+1] == :XY
         backtrack(lengths, backtracks, removed, added, X, Y, i-1, j-1)
-    elseif j > 0 && (i == 0 || backtracks[i, j] == :X)
+    elseif j > 0 && (i == 0 || backtracks[i+1, j+1] == :X)
         backtrack(lengths, backtracks, removed, added, X, Y, i, j-1)
         push!(added, j)
-    elseif i > 0 && (j == 0 ||  backtracks[i, j] == :Y)
+    elseif i > 0 && (j == 0 ||  backtracks[i+1, j+1] == :Y)
         backtrack(lengths, backtracks, removed, added, X, Y, i-1, j)
         push!(removed, i)
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -50,13 +50,14 @@ end
 # recursively trace back the longest common subsequence, adding items
 # to the added and removed lists as we go
 function backtrack(lengths, backtracks, removed, added, X, Y, i, j)
-    if backtracks[i+1, j+1] == (1, 1)
-        backtrack(lengths, backtracks, removed, added, X, Y, i-1, j-1)
-    elseif backtracks[i+1, j+1] == (0, 1)
-        backtrack(lengths, backtracks, removed, added, X, Y, i, j-1)
+    bt = backtracks[i+1, j+1]
+    if bt == (1, 1)
+        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
+    elseif bt == (0, 1)
+        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
         push!(added, j)
-    elseif backtracks[i+1, j+1] == (1, 0)
-        backtrack(lengths, backtracks, removed, added, X, Y, i-1, j)
+    elseif bt == (1, 0)
+        backtrack(lengths, backtracks, removed, added, X, Y, ((i, j) .- bt)...)
         push!(removed, i)
     end
 end

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -26,7 +26,7 @@ function deepdiff(X::AbstractDict, Y::AbstractDict)
     changed = Dict{eltype(bothkeys), DeepDiff}()
 
     for key in bothkeys
-        if X[key] != Y[key]
+        if !isequal(X[key], Y[key])
             changed[key] = deepdiff(X[key], Y[key])
         else
             push!(unchanged, key)

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -44,4 +44,10 @@
     d = deepdiff(a1, [2, 4])
     @test removed(d) == [1, 3]
     @test added(d) == []
+
+    d = deepdiff([NaN], [NaN])
+    @test removed(d) == added(d) == []
+
+    d = deepdiff([missing], [missing])
+    @test removed(d) == added(d) == []
 end

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -50,4 +50,7 @@
 
     d = deepdiff([missing], [missing])
     @test removed(d) == added(d) == []
+
+    d = deepdiff([NaN], [])
+    @test d == d
 end

--- a/test/dicts.jl
+++ b/test/dicts.jl
@@ -86,4 +86,30 @@
         @test removed(d) == Set()
         @test changed(d) == Dict()
     end
+
+    @testset "missing/NaN" begin
+        dnan = Dict(:d=>NaN)
+        d = deepdiff(dnan, dnan)
+        @test added(d) == removed(d) == Set()
+        @test changed(d) == Dict()
+
+        dmis = Dict(:d=>missing)
+        d = deepdiff(dmis, dmis)
+        @test added(d) == removed(d) == Set()
+        @test changed(d) == Dict()
+
+        dnank = Dict(NaN=>true)
+        d = deepdiff(dnan, dnan)
+        @test added(d) == removed(d) == Set()
+        @test changed(d) == Dict()
+
+        dmisk = Dict(missing=>true)
+        d = deepdiff(dmis, dmis)
+        @test added(d) == removed(d) == Set()
+        @test changed(d) == Dict()
+
+        d = DeepDiffs.deepdiff(dnank, dmisk)
+        @test d == d
+
+    end
 end


### PR DESCRIPTION
This is pretty much purely an aesthetic suggestion to deduplicate the logic (prompted because I had to change `==` -> `isequal` in two places in https://github.com/ssfrr/DeepDiffs.jl/pull/14 . This PR depends on that PR.)

I feel like the changes lie on a spectrum. For that reason, I broke the change out into a million commits. If the code at the last commit doesn't look so great, perhaps one just before is better. Also, each commit mostly represents a straightforward transformation.

