### PR TITLE
Avoid escaping quotes in multiline string

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Spencer Russell"]
 keywords = ["diff"]
 license = "MIT"
 desc = "Compute and pretty-print diffs for data structures like arrays and dictionaries"
-version = "1.2.1"
+version = "1.2.2"
 
 [compat]
 julia = "1.6"

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -35,7 +35,8 @@ changed(diff::AllStringDiffs) = []
 
 Base.:(==)(d1::T, d2::T) where {T<:AllStringDiffs} = fieldequal(d1, d2)
 
-escape_diff_line(str::AbstractString) = escape_string(str, ('$'); keep=('\"'))
+escape_diff(str::AbstractString) = escape_string(str, ('$'); keep=('\"'))
+escape_diff(char::AbstractChar) = escape_string(string(char), ('$', '\"'))
 
 function Base.show(io::IO, diff::StringLineDiff)
     xlines = split(diff.before, '\n')
@@ -43,11 +44,11 @@ function Base.show(io::IO, diff::StringLineDiff)
     println(io, "\"\"\"")
     visitall(diff.diff) do idx, state, last
         if state == :removed
-            printstyled(io, "- ", escape_diff_line(xlines[idx]), color=:red)
+            printstyled(io, "- ", escape_diff(xlines[idx]), color=:red)
         elseif state == :added
-            printstyled(io, "+ ", escape_diff_line(ylines[idx]), color=:green)
+            printstyled(io, "+ ", escape_diff(ylines[idx]), color=:green)
         else
-            print(io, "  ", escape_diff_line(xlines[idx]))
+            print(io, "  ", escape_diff(xlines[idx]))
         end
         if last
             print(io, "\"\"\"")
@@ -79,11 +80,11 @@ function Base.show(io::IO, diff::StringDiff)
             end
         end
         if state == :removed
-            printstyled(io, string(xchars[idx]), color=:red)
+            printstyled(io, escape_diff(xchars[idx]), color=:red)
         elseif state == :added
-            printstyled(io, string(ychars[idx]), color=:green)
+            printstyled(io, escape_diff(ychars[idx]), color=:green)
         else
-            print(io, xchars[idx])
+            print(io, escape_diff(xchars[idx]))
         end
         laststate = state
     end

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -35,7 +35,7 @@ changed(diff::AllStringDiffs) = []
 
 Base.:(==)(d1::T, d2::T) where {T<:AllStringDiffs} = fieldequal(d1, d2)
 
-escape_diff(str::AbstractString) = escape_string(str, ('$'); keep=('\"'))
+escape_diff(str::AbstractString) = escape_string(str, ('$',))
 escape_diff(char::AbstractChar) = escape_string(string(char), ('$', '\"'))
 
 function Base.show(io::IO, diff::StringLineDiff)

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -35,17 +35,19 @@ changed(diff::AllStringDiffs) = []
 
 Base.:(==)(d1::T, d2::T) where {T<:AllStringDiffs} = fieldequal(d1, d2)
 
+escape_diff_line(str::AbstractString) = escape_string(str, ('$'); keep=('\"'))
+
 function Base.show(io::IO, diff::StringLineDiff)
     xlines = split(diff.before, '\n')
     ylines = split(diff.after, '\n')
-    println(io, "raw\"\"\"")
+    println(io, "\"\"\"")
     visitall(diff.diff) do idx, state, last
         if state == :removed
-            printstyled(io, "- ", xlines[idx], color=:red)
+            printstyled(io, "- ", escape_diff_line(xlines[idx]), color=:red)
         elseif state == :added
-            printstyled(io, "+ ", ylines[idx], color=:green)
+            printstyled(io, "+ ", escape_diff_line(ylines[idx]), color=:green)
         else
-            print(io, "  ", xlines[idx])
+            print(io, "  ", escape_diff_line(xlines[idx]))
         end
         if last
             print(io, "\"\"\"")

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -38,14 +38,14 @@ Base.:(==)(d1::T, d2::T) where {T<:AllStringDiffs} = fieldequal(d1, d2)
 function Base.show(io::IO, diff::StringLineDiff)
     xlines = split(diff.before, '\n')
     ylines = split(diff.after, '\n')
-    println(io, "\"\"\"")
+    println(io, "raw\"\"\"")
     visitall(diff.diff) do idx, state, last
         if state == :removed
-            printstyled(io, "- ", escape_string(xlines[idx]), color=:red)
+            printstyled(io, "- ", xlines[idx], color=:red)
         elseif state == :added
-            printstyled(io, "+ ", escape_string(ylines[idx]), color=:green)
+            printstyled(io, "+ ", ylines[idx], color=:green)
         else
-            print(io, "  ", escape_string(xlines[idx]))
+            print(io, "  ", xlines[idx])
         end
         if last
             print(io, "\"\"\"")

--- a/test/display.jl
+++ b/test/display.jl
@@ -150,11 +150,11 @@
     end
 
     @testset "Multi-line strings display correctly" begin
-    s1 = raw"""
+    s1 = """
         differences can
         be "hard" to find
-        $in
-        multiline
+        \$in
+        \tmultiline\0
         output"""
     s2 = """
         differences can
@@ -165,12 +165,13 @@
     @testset "Color Display" begin
         buf = setcolor(true)
         expected = raw"""
-        raw\"\"\"
+        \"\"\"
           differences can
         [31m- be "hard" to find[39m
-        [31m- $in[39m
+        [31m- \$in[39m
+        [31m- \tmultiline\0[39m
         [32m+ be hurd to find[39m
-          multiline
+        [32m+ multiline[39m
           output\"\"\""""
         display(TextDisplay(buf), diff)
         @test strip(String(take!(buf.io))) == expected
@@ -179,12 +180,13 @@
         buf = setcolor(false)
         display(TextDisplay(buf), diff)
         @test strip(String(take!(buf.io))) == raw"""
-        raw\"\"\"
+        \"\"\"
           differences can
         - be "hard" to find
-        - $in
+        - \$in
+        - \tmultiline\0
         + be hurd to find
-          multiline
+        + multiline
           output\"\"\""""
     end
     resetcolor()

--- a/test/display.jl
+++ b/test/display.jl
@@ -150,10 +150,10 @@
     end
 
     @testset "Multi-line strings display correctly" begin
-    s1 = """
+    s1 = raw"""
         differences can
-        be hard to find
-        in
+        be "hard" to find
+        $in
         multiline
         output"""
     s2 = """
@@ -164,11 +164,11 @@
     diff = deepdiff(s1, s2)
     @testset "Color Display" begin
         buf = setcolor(true)
-        expected = """
-        \"\"\"
+        expected = raw"""
+        raw\"\"\"
           differences can
-        [31m- be hard to find[39m
-        [31m- in[39m
+        [31m- be "hard" to find[39m
+        [31m- $in[39m
         [32m+ be hurd to find[39m
           multiline
           output\"\"\""""
@@ -178,11 +178,11 @@
     @testset "No-Color Display" begin
         buf = setcolor(false)
         display(TextDisplay(buf), diff)
-        @test strip(String(take!(buf.io))) == """
-        \"\"\"
+        @test strip(String(take!(buf.io))) == raw"""
+        raw\"\"\"
           differences can
-        - be hard to find
-        - in
+        - be "hard" to find
+        - $in
         + be hurd to find
           multiline
           output\"\"\""""

--- a/test/display.jl
+++ b/test/display.jl
@@ -146,6 +146,11 @@
         buf = setcolor(false)
         display(TextDisplay(buf), diff)
         @test strip(String(take!(buf.io))) == "\"a{+d+}b{-c-}\""
+
+        diff = deepdiff("a\0\"\$b", "a\"\$b")
+        buf = setcolor(false)
+        display(TextDisplay(buf), diff)
+        @test strip(String(take!(buf.io))) == raw"\"a{-\0-}\\\"\$b\""
         resetcolor()
     end
 

--- a/test/display.jl
+++ b/test/display.jl
@@ -147,10 +147,10 @@
         display(TextDisplay(buf), diff)
         @test strip(String(take!(buf.io))) == "\"a{+d+}b{-c-}\""
 
-        diff = deepdiff("a\0\"\$b", "a\"\$b")
+        diff = deepdiff("a\0\"b", "a\"\$b")
         buf = setcolor(false)
         display(TextDisplay(buf), diff)
-        @test strip(String(take!(buf.io))) == raw"\"a{-\0-}\\\"\$b\""
+        @test strip(String(take!(buf.io))) == raw"\"a{-\0-}\\\"{+\$+}b\""
         resetcolor()
     end
 
@@ -159,12 +159,12 @@
         differences can
         be "hard" to find
         \$in
-        \tmultiline\0
+        \tmultiline
         output"""
     s2 = """
         differences can
         be hurd to find
-        multiline
+        multiline\0
         output"""
     diff = deepdiff(s1, s2)
     @testset "Color Display" begin
@@ -174,9 +174,9 @@
           differences can
         [31m- be "hard" to find[39m
         [31m- \$in[39m
-        [31m- \tmultiline\0[39m
+        [31m- \tmultiline[39m
         [32m+ be hurd to find[39m
-        [32m+ multiline[39m
+        [32m+ multiline\0[39m
           output\"\"\""""
         display(TextDisplay(buf), diff)
         @test strip(String(take!(buf.io))) == expected
@@ -189,9 +189,9 @@
           differences can
         - be "hard" to find
         - \$in
-        - \tmultiline\0
+        - \tmultiline
         + be hurd to find
-        + multiline
+        + multiline\0
           output\"\"\""""
     end
     resetcolor()


### PR DESCRIPTION
I noticed when using ReferenceTests.jl that the displayed diff was escaping my quotes when shown. This was making me think that the original content was using escaped quotes instead of just regular quotes:

```julia
julia> using DeepDiffs

julia> reference = ""
""

julia> actual = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites tests=\"1\" failures=\"1\" errors=\"0\">\n  <testsuite name=\"reporttest\" tests=\"1\" failures=\"1\" errors=\"0\" time=\"0.0\" timestamp=\"0\" hostname=\"localhost\" id=\"0\">\n    <testcase name=\"ARGS == []\" id=\"1\" classname=\"reporttest\" time=\"0.0\">\n      <failure message=\"[&quot;foo&quot;, &quot;-e&quot;, &quot;bar&quot;] == Any[]\" type=\"test\">Test Failed\n  Expression: ARGS == []\n   Evaluated: [\"foo\", \"-e\", \"bar\"] == Any[]\n</failure>\n    </testcase>\n  </testsuite>\n</testsuites>\n"
"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites tests=\"1\" failures=\"1\" errors=\"0\">\n  <testsuite name=\"reporttest\" tests=\"1\" failures=\"1\" errors=\"0\" time=\"0.0\" timestamp=\"0\" hostname=\"localhost\" id=\"0\">\n    <testcase name=\"ARGS == []\" id=\"1\" classname=\"reporttest\" time=\"0.0\">\n      <failure message=\"[&quot;foo&quot;, &quot;-e&quot;, &quot;bar&quot;] == Any[]\" type=\"test\">Test Failed\n  Expression: ARGS == []\n   Evaluated: [\"foo\", \"-e\", \"bar\"] == Any[]\n</failure>\n    </testcase>\n  </testsuite>\n</testsuites>\n"

julia> print(deepdiff(reference, actual))
"""
+ <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+ <testsuites tests=\"1\" failures=\"1\" errors=\"0\">
+   <testsuite name=\"reporttest\" tests=\"1\" failures=\"1\" errors=\"0\" time=\"0.0\" timestamp=\"0\" hostname=\"localhost\" id=\"0\">
+     <testcase name=\"ARGS == []\" id=\"1\" classname=\"reporttest\" time=\"0.0\">
+       <failure message=\"[&quot;foo&quot;, &quot;-e&quot;, &quot;bar&quot;] == Any[]\" type=\"test\">Test Failed
+   Expression: ARGS == []
+    Evaluated: [\"foo\", \"-e\", \"bar\"] == Any[]
+ </failure>
+     </testcase>
+   </testsuite>
+ </testsuites>
  """
```

This PR changes the `show` method to use a `@raw_str` so that we can show a cleaner string diff:
```julia
julia> print(deepdiff(reference, actual))
raw"""
+ <?xml version="1.0" encoding="UTF-8"?>
+ <testsuites tests="1" failures="1" errors="0">
+   <testsuite name="reporttest" tests="1" failures="1" errors="0" time="0.0" timestamp="0" hostname="localhost" id="0">
+     <testcase name="ARGS == []" id="1" classname="reporttest" time="0.0">
+       <failure message="[&quot;foo&quot;, &quot;-e&quot;, &quot;bar&quot;] == Any[]" type="test">Test Failed
+   Expression: ARGS == []
+    Evaluated: ["foo", "-e", "bar"] == Any[]
+ </failure>
+     </testcase>
+   </testsuite>
+ </testsuites>
  """
```